### PR TITLE
Introduce Git helper utilities and integrate repository checks

### DIFF
--- a/src/common/git.cpp
+++ b/src/common/git.cpp
@@ -1,0 +1,67 @@
+#include "git.h"
+
+#include <array>
+#include <cstdio>
+
+#ifdef _WIN32
+#define popen _popen
+#define pclose _pclose
+#endif
+
+namespace GitUtils {
+
+std::string findRepoRoot(const std::filesystem::path &start) {
+    std::filesystem::path current = start;
+    if (std::filesystem::is_regular_file(current)) {
+        current = current.parent_path();
+    }
+    while (!current.empty()) {
+        if (std::filesystem::exists(current / ".git")) {
+            return current.string();
+        }
+        if (current == current.root_path()) {
+            break;
+        }
+        current = current.parent_path();
+    }
+    return "";
+}
+
+bool isRepository(const std::filesystem::path &path) {
+    return !findRepoRoot(path).empty();
+}
+
+std::string getLastCommitMessage(const std::string &repoRoot,
+                                const std::string &filePath,
+                                int maxLen) {
+    if (repoRoot.empty()) {
+        return "";
+    }
+
+    std::string command = "git -C \"" + repoRoot + "\" log -1 --pretty=%B";
+    if (!filePath.empty()) {
+        command += " -- \"" + filePath + "\"";
+    }
+
+    std::array<char, 256> buffer{};
+    std::string result;
+    FILE *pipe = popen(command.c_str(), "r");
+    if (!pipe) {
+        return "";
+    }
+    while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe) != nullptr) {
+        result += buffer.data();
+    }
+    pclose(pipe);
+
+    while (!result.empty() && (result.back() == '\n' || result.back() == '\r')) {
+        result.pop_back();
+    }
+    if (maxLen > 0 && static_cast<int>(result.size()) > maxLen) {
+        result = result.substr(0, maxLen);
+    }
+    return result;
+}
+
+} // namespace GitUtils
+

--- a/src/common/git.h
+++ b/src/common/git.h
@@ -1,0 +1,27 @@
+#pragma once
+#ifndef GIT_SYNC_D_GIT_H
+#define GIT_SYNC_D_GIT_H
+
+#include <filesystem>
+#include <string>
+
+namespace GitUtils {
+
+// Return the path to the repository root that contains `path`.
+// If `path` is not inside a repository, an empty string is returned.
+std::string findRepoRoot(const std::filesystem::path &path);
+
+// Check whether `path` resides within a Git repository.
+bool isRepository(const std::filesystem::path &path);
+
+// Retrieve the latest commit message for `filePath` inside `repoRoot`.
+// If `filePath` is empty, the latest commit message for the repository is returned.
+// The result is truncated to `maxLen` characters when `maxLen` is positive.
+std::string getLastCommitMessage(const std::string &repoRoot,
+                                const std::string &filePath = "",
+                                int maxLen = 0);
+
+} // namespace GitUtils
+
+#endif // GIT_SYNC_D_GIT_H
+

--- a/src/common/ipc.h
+++ b/src/common/ipc.h
@@ -121,7 +121,6 @@ bool parseCommands(
     std::mutex& responses_vectors_mutex);
 bool parseKeyValue(std::string& input, std::string& keys, std::string& values);
 bool parseTimeFrame(std::string& input, size_t& time_frame);
-bool withinRepo(std::string& path);
 void run(IPC&);
 
 #if defined(BOOST_ASIO_HAS_WINDOWS_STREAM_HANDLE)


### PR DESCRIPTION
## Summary
- add `GitUtils` helpers to locate repositories and fetch commit messages
- validate IPC file and directory additions using `GitUtils::isRepository`
- fix local socket restart logic for Boost ASIO

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_689ce7d93c60832da705c4aea83af849