### PR TITLE
Add basic file watcher and git sync helpers

### DIFF
--- a/src/common/git.cpp
+++ b/src/common/git.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstdio>
+#include <cstdlib>
 
 #ifdef _WIN32
 #define popen _popen
@@ -61,6 +62,25 @@ std::string getLastCommitMessage(const std::string &repoRoot,
         result = result.substr(0, maxLen);
     }
     return result;
+}
+
+static bool runCommand(const std::string &command) {
+    return std::system(command.c_str()) == 0;
+}
+
+bool stageFile(const std::string &repoRoot, const std::string &filePath) {
+    std::string cmd = "git -C \"" + repoRoot + "\" add \"" + filePath + "\"";
+    return runCommand(cmd);
+}
+
+bool commit(const std::string &repoRoot, const std::string &message) {
+    std::string cmd = "git -C \"" + repoRoot + "\" commit -m \"" + message + "\"";
+    return runCommand(cmd);
+}
+
+bool push(const std::string &repoRoot) {
+    std::string cmd = "git -C \"" + repoRoot + "\" push";
+    return runCommand(cmd);
 }
 
 } // namespace GitUtils

--- a/src/common/git.h
+++ b/src/common/git.h
@@ -21,6 +21,15 @@ std::string getLastCommitMessage(const std::string &repoRoot,
                                 const std::string &filePath = "",
                                 int maxLen = 0);
 
+// Stage `filePath` in the repository located at `repoRoot`.
+bool stageFile(const std::string &repoRoot, const std::string &filePath);
+
+// Commit staged changes in `repoRoot` using `message`.
+bool commit(const std::string &repoRoot, const std::string &message);
+
+// Push committed changes from `repoRoot` to its configured remote.
+bool push(const std::string &repoRoot);
+
 } // namespace GitUtils
 
 #endif // GIT_SYNC_D_GIT_H


### PR DESCRIPTION
## Summary
- add git helpers to stage, commit and push changes
- poll database entries for file changes and sync to destination repos

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: fatal error: boost/asio.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cf2aea620832daf90806dce976b32