### PR TITLE
Use popen-based git helpers for git operations

### DIFF
--- a/src/common/git.h
+++ b/src/common/git.h
@@ -22,13 +22,16 @@ std::string getLastCommitMessage(const std::string &repoRoot,
                                 int maxLen = 0);
 
 // Stage `filePath` in the repository located at `repoRoot`.
-bool stageFile(const std::string &repoRoot, const std::string &filePath);
+// Returns the Git CLI exit code.
+int stageFile(const std::string &repoRoot, const std::string &filePath);
 
 // Commit staged changes in `repoRoot` using `message`.
-bool commit(const std::string &repoRoot, const std::string &message);
+// Returns the Git CLI exit code.
+int commit(const std::string &repoRoot, const std::string &message);
 
-// Push committed changes from `repoRoot` to its configured remote.
-bool push(const std::string &repoRoot);
+// Push committed changes from `repoRoot` to `remoteName`.
+// Returns the Git CLI exit code.
+int push(const std::string &repoRoot, const std::string &remoteName);
 
 } // namespace GitUtils
 

--- a/src/common/mainLogic.cpp
+++ b/src/common/mainLogic.cpp
@@ -38,10 +38,22 @@ namespace MainLogic_H
                             std::filesystem::copy_file(
                                 src, dstRepo / src.filename(),
                                 std::filesystem::copy_options::overwrite_existing);
-                            GitUtils::stageFile(dstRepo.string(),
-                                                 (dstRepo / src.filename()).string());
-                            GitUtils::commit(dstRepo.string(), msg);
-                            GitUtils::push(dstRepo.string());
+                            std::string target = (dstRepo / src.filename()).string();
+                            if (GitUtils::stageFile(dstRepo.string(), target) != 0) {
+                                GIT_SYNC_D_MESSAGE::Error::error(
+                                    "Failed to stage file",
+                                    GIT_SYNC_D_MESSAGE::_ErrorCode::GENERIC_ERROR);
+                            }
+                            if (GitUtils::commit(dstRepo.string(), msg) != 0) {
+                                GIT_SYNC_D_MESSAGE::Error::error(
+                                    "Failed to commit changes",
+                                    GIT_SYNC_D_MESSAGE::_ErrorCode::GENERIC_ERROR);
+                            }
+                            if (GitUtils::push(dstRepo.string(), "origin") != 0) {
+                                GIT_SYNC_D_MESSAGE::Error::error(
+                                    "Failed to push changes",
+                                    GIT_SYNC_D_MESSAGE::_ErrorCode::GENERIC_ERROR);
+                            }
                         }
                     }
                     else
@@ -63,10 +75,22 @@ namespace MainLogic_H
                             std::filesystem::copy_file(
                                 src, dstRepo / src.filename(),
                                 std::filesystem::copy_options::overwrite_existing);
-                            GitUtils::stageFile(dstRepo.string(),
-                                                 (dstRepo / src.filename()).string());
-                            GitUtils::commit(dstRepo.string(), msg);
-                            GitUtils::push(dstRepo.string());
+                            std::string target = (dstRepo / src.filename()).string();
+                            if (GitUtils::stageFile(dstRepo.string(), target) != 0) {
+                                GIT_SYNC_D_MESSAGE::Error::error(
+                                    "Failed to stage file",
+                                    GIT_SYNC_D_MESSAGE::_ErrorCode::GENERIC_ERROR);
+                            }
+                            if (GitUtils::commit(dstRepo.string(), msg) != 0) {
+                                GIT_SYNC_D_MESSAGE::Error::error(
+                                    "Failed to commit changes",
+                                    GIT_SYNC_D_MESSAGE::_ErrorCode::GENERIC_ERROR);
+                            }
+                            if (GitUtils::push(dstRepo.string(), "origin") != 0) {
+                                GIT_SYNC_D_MESSAGE::Error::error(
+                                    "Failed to push changes",
+                                    GIT_SYNC_D_MESSAGE::_ErrorCode::GENERIC_ERROR);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Add popen-based Git helpers returning exit codes: stageFile, commit, push
- Integrate new helpers into MainLogic with error reporting
- Support pushing to a specified remote

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_689cf433380c832dbb0c2128ec2157f0