### PR TITLE
Implement sync management helpers and IPC integration

### DIFF
--- a/src/common/mainLogic.h
+++ b/src/common/mainLogic.h
@@ -31,6 +31,20 @@ namespace MainLogic_H
     void stop();
     bool IsServiceStopped();
     void setLogEvent(std::function<void(std::string, GIT_SYNC_D_MESSAGE::_ErrorCode)>);
+
+    // Add or remove file/directory synchronisation entries in the database.
+    // These functions also restart any file watchers so that changes take
+    // effect immediately.
+    bool addFile(const std::string &filePath,
+                 const std::string &repoPath,
+                 const std::string &options);
+
+    bool addDirectory(const std::string &dirPath,
+                      const std::string &repoPath,
+                      const std::string &options);
+
+    // Remove a sync entry (file or directory) identified by its path.
+    bool removeSync(const std::string &path);
     
 }
 #endif // MAINLOGIC_H


### PR DESCRIPTION
## Summary
- Add `addFile`, `addDirectory`, and `removeSync` helpers in `MainLogic` that update the DB and trigger watcher refresh
- Hook IPC command handling to these helpers and return success/error codes
- Clear watcher caches when synchronisation list changes

## Testing
- `cmake ..`
- `make` *(fails: undefined references to CryptoPP)*

------
https://chatgpt.com/codex/tasks/task_e_689cf55e1b68832dab5de86d8e8d0682